### PR TITLE
Merge upstream changes - including update of paypal/paypalhttp_php to v1.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-# REST API SDK for PHP V2
+# Deprecation Notice:
+This SDK is deprecated; you can continue to use it, but no new features or support requests will be accepted. A direct [REST API integration](https://developer.paypal.com/docs/api/orders/v2/) is recommended. Review the [docs on authorization](https://developer.paypal.com/api/rest/authentication/) for authenticating requests with the REST API.
+
+## REST API SDK for PHP V2
 
 ![Home Image](homepage.jpg)
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ __Welcome to PayPal PHP SDK__. This repository contains PayPal's PHP SDK and sam
 
 This is a part of the next major PayPal SDK. It includes a simplified interface to only provide simple model objects and blueprints for HTTP calls. This repo currently contains functionality for PayPal Checkout APIs which includes [Orders V2](https://developer.paypal.com/docs/api/orders/v2/) and [Payments V2](https://developer.paypal.com/docs/api/payments/v2/).
 
-Please refer to the [PayPal Checkout Integration Guide](https://developer.paypal.com/docs/checkout/) for more information. Also refer to [Setup your SDK](https://developer.paypal.com/docs/checkout/reference/server-integration/setup-sdk/) for additional information about setting up the SDK's. 
+Please refer to the [PayPal Checkout Integration Guide](https://developer.paypal.com/docs/checkout/) for more information. 
 ## Latest Updates
 Beginning January 2020, PayPal will require an update on the Personal Home Page (PHP) Checkout Software Developer Kit (SDK) to version 1.0.1. Merchants who have not updated their PHP Checkout SDK to version 1.0.1 will not be able to deserialize responses using outdated SDK integrations.
 All PHP Checkout SDK integrations are expected to be updated by March 1, 2020. Merchants are encouraged to prepare for the update as soon as possible to avoid possible service disruption.

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "PayPal's PHP SDK for Checkout REST APIs",
     "keywords": ["paypal", "payments", "rest", "sdk", "orders", "checkout"],
     "type": "library",
-    "license": "https://github.com/paypal/Checkout-PHP-SDK/blob/master/LICENSE",
+    "license": "Apache-2.0",
     "homepage": "http://github.com/paypal/Checkout-PHP-SDK/",
     "require": {
         "paypal/paypalhttp": "1.0.1"

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "license": "https://github.com/paypal/Checkout-PHP-SDK/blob/master/LICENSE",
     "homepage": "http://github.com/paypal/Checkout-PHP-SDK/",
     "require": {
-        "paypal/paypalhttp": "1.0.0"
+        "paypal/paypalhttp": "1.0.1"
     },
     "authors": [
         {

--- a/lib/PayPalCheckoutSdk/Core/FPTIInstrumentationInjector.php
+++ b/lib/PayPalCheckoutSdk/Core/FPTIInstrumentationInjector.php
@@ -9,7 +9,7 @@ class FPTIInstrumentationInjector implements Injector
     public function inject($request)
     {
         $request->headers["sdk_name"] = "Checkout SDK";
-        $request->headers["sdk_version"] = "1.0.1";
+        $request->headers["sdk_version"] = "1.0.2";
         $request->headers["sdk_tech_stack"] = "PHP " . PHP_VERSION;
         $request->headers["api_integration_type"] = "PAYPALSDK";
     }

--- a/lib/PayPalCheckoutSdk/Core/Version.php
+++ b/lib/PayPalCheckoutSdk/Core/Version.php
@@ -4,5 +4,5 @@ namespace PayPalCheckoutSdk\Core;
 
 class Version
 {
-    const VERSION = "1.0.1";
+    const VERSION = "1.0.2";
 }


### PR DESCRIPTION
Most important change: library [paypalhttp_php](https://github.com/paypal/paypalhttp_php) has a wrong type hint in the `HttpResponse` class for the `$result`. This has been fixed in v1.0.1 which leads to less errors in IDEs or downstream code.